### PR TITLE
Add negative scenario for non-existing news article

### DIFF
--- a/src/main/java/copy/Copy.java
+++ b/src/main/java/copy/Copy.java
@@ -1,6 +1,7 @@
 package copy;
 
 public class Copy {
-    public static final String NON_EXISTING_NEWS_KEYWORD = "JP Morgan is largest bank in the world";
+    public static final String NON_EXISTING_NEWS_KEYWORD = "asdlkjfhgqwertynonexisting12345";
     public static final String FAKE_MESSAGE_TEXT = "News is fake as match is less then 2";
 }
+

--- a/src/test/java/pageObjectsModels/pageActions/NewsPageActions.java
+++ b/src/test/java/pageObjectsModels/pageActions/NewsPageActions.java
@@ -1,5 +1,6 @@
 package pageObjectsModels.pageActions;
 
+import copy.Copy;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -48,6 +49,11 @@ public class NewsPageActions extends BasePage {
         logger.info("Article Title " + articleTitle);
         logger.info("Article Content " + articleContent);
         performGoogleSearch(articleTitle + " " + articleContent);
+    }
+
+    public void searchForNonExistingNews() {
+        logger.info("Searching for non-existing news using keyword: " + Copy.NON_EXISTING_NEWS_KEYWORD);
+        performGoogleSearch(Copy.NON_EXISTING_NEWS_KEYWORD);
     }
 
     /**

--- a/src/test/java/stepDefinitions/NewsValidationStepDefinitions.java
+++ b/src/test/java/stepDefinitions/NewsValidationStepDefinitions.java
@@ -44,11 +44,11 @@ public class NewsValidationStepDefinitions {
 
     @When("the user searches for a non-existing article title and content on Google")
     public void iSearchForANonExistingArticleTitleAndContentOnGoogle() {
-        newsPage.searchForNews();
+        newsPage.searchForNonExistingNews();
         logger.info("Search for news on google for non-existing article");
     }
 
-    @Then("no search results should be displayed")
+    @Then("no matching results should be found")
     public void iShouldSeeNoResults() {
         assertTrue(Copy.FAKE_MESSAGE_TEXT, newsPage.verifyMatchingResults(0));
         logger.info("no search result assertion is in progress");

--- a/src/test/resources/config/testconfig.properties
+++ b/src/test/resources/config/testconfig.properties
@@ -2,3 +2,4 @@ url= https://www.theguardian.com/tone/news
 
 #==============Browser Specifications=================
 browser=edge
+

--- a/src/test/resources/features/news_validation.feature
+++ b/src/test/resources/features/news_validation.feature
@@ -14,4 +14,5 @@ Feature: News Validation
     Given the user is on The Guardian news page
     And the user extracts the title and content of the first news article
     When the user searches for a non-existing article title and content on Google
-    Then no search results should be displayed
+    Then no matching results should be found
+


### PR DESCRIPTION
## Summary
- Add constant with random keyword for non-existing news
- Support searching for non-existing articles in page actions and step definitions
- Clarify BDD scenarios for validating first Guardian article

## Testing
- `mvn -q -e test -Dbrowser=edge` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.0.2 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689df10e2d508332b61d4c48d250a5d1